### PR TITLE
Dinner cards renders differently depending if a recipe has been added…

### DIFF
--- a/api/mergedData.js
+++ b/api/mergedData.js
@@ -4,9 +4,11 @@ import { getSingleRecipe } from './recipesData';
 // // GET RECIPE ON DINNER CARD
 const getRecipeOnDinnerCard = (dayId) => new Promise((resolve, reject) => {
   getDinnersByDay(dayId).then((dinnersArray) => {
+    console.warn(dinnersArray, 'dinner array');
     const recipeIdPromises = dinnersArray.map((dinners) => getSingleRecipe(dinners.recipeId));
 
     Promise.all(recipeIdPromises).then((recipeArray) => {
+      console.warn(recipeArray);
       resolve(recipeArray[0]);
     });
   })

--- a/components/cards/dinnerCards.js
+++ b/components/cards/dinnerCards.js
@@ -6,12 +6,15 @@ import Card from 'react-bootstrap/Card';
 import Button from 'react-bootstrap/Button';
 import RecipeCards from './recipeCards';
 import getRecipeOnDinnerCard from '../../api/mergedData';
+import { getDinnersByDay } from '../../api/dinnersData';
 
-function DinnerCards({ dayObj, dinnerObj }) {
-  const [recipes, setRecipes] = useState({});
+function DinnerCards({ dayObj }) {
+  const [recipe, setRecipe] = useState({});
+  const [dinnerObj, setDinnerObj] = useState({});
 
   useEffect(() => {
-    getRecipeOnDinnerCard(dayObj.firebaseKey).then(setRecipes);
+    getRecipeOnDinnerCard(dayObj.firebaseKey).then(setRecipe);
+    getDinnersByDay(dayObj.firebaseKey).then(setDinnerObj);
   }, []);
 
   return (
@@ -19,11 +22,12 @@ function DinnerCards({ dayObj, dinnerObj }) {
       <Card style={{ width: '18rem' }}>
         <Card.Body>
           <Card.Title>{dayObj.day}</Card.Title>
-          {/* {dayObj.firebaseKey === dinnerObj.dayId && ()} */}
-          <RecipeCards key={dinnerObj.recipeId} recipeObj={recipes} />
+          {dayObj.firebaseKey === dinnerObj[0]?.dayId && (
+            <RecipeCards key={dinnerObj.recipeId} recipeObj={recipe} />
+          )}
         </Card.Body>
         <footer>
-          {dayObj.firebaseKey === dinnerObj.dayId ? (
+          {dayObj.firebaseKey === dinnerObj[0]?.dayId ? (
             <div className="edit-delete-footer">
               <Card.Link href={`/dinners/edit/${dinnerObj.firebaseKey}`}>
                 <Button variant="warning" className="edit-btn">Edit</Button>
@@ -46,16 +50,10 @@ DinnerCards.propTypes = {
     day: PropTypes.string,
     firebaseKey: PropTypes.string,
   }),
-  dinnerObj: PropTypes.shape({
-    recipeId: PropTypes.string,
-    dayId: PropTypes.string,
-    firebaseKey: PropTypes.string,
-  }),
 };
 
 DinnerCards.defaultProps = {
   dayObj: {},
-  dinnerObj: {},
 };
 
 export default DinnerCards;


### PR DESCRIPTION
… to the card or not. If a recipe has been added, the dinner card now renders the recipe card, the edit button and the delete button. Used getDinnersByDay and set it to another State called dinnerObj. In my conditionals, I am looking to see if the dayObj's firebaseKey matches the dinnerObj's dayId. If it does, then it means there's a join table entity in firebase and it will pull the recipe card and render the two buttons. If not, then dinner card will only render the name of the day and the add button